### PR TITLE
Remove an unnecessary space in message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -87,7 +87,7 @@
     "badge-appreciated": "appreciated",
     "badge-appreciated-desc": "You were appreciated a significant amount of times. You are a pillar to your community!",
     "badge-proofreader": "proofreader",
-    "badge-proofreader-desc": "You proof read over 50 pages! Impressive!",
+    "badge-proofreader-desc": "You proofread over 50 pages! Impressive!",
     "badge-template-wizard": "template wizard",
     "badge-template-wizard-desc": "You edited more than 50 pages in the Module and Template namespace",
     "badge-interface-hero": "interface hero",


### PR DESCRIPTION
"Proofread" as a verb is usually written with no space.